### PR TITLE
MongoDB backend and default LocalUploadBackend

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,41 +10,59 @@ Step 1. Install django-ajax-uploader.
 -------------------------------------
 Right now, you can either:
 
--	Download and install, or
--	`pip install -e git://github.com/GoodCloud/django-ajax-uploader.git#egg=ajaxuploader`  it from here. If there's demand, I'll look into pypi. 
+- Download and install, or
+- `pip install -e git://github.com/GoodCloud/django-ajax-uploader.git#egg=ajaxuploader` it from here. If there's 
+demand, I'll look into pypi.
+- If you plan on using the Amazon S3 backend you will also need to install [boto](https://github.com/boto/boto)
 
-Step 2. Include it in your app's views and urls.
+	$ pip install boto
+
+
+Step 2. (Django 1.3 only)
+-------------------------
+For Django 1.3 you will need to have the app in your installed apps tuple for collect static to pick up the files.
+
+1. Add 'ajaxuploader' to you installed apps in settings.py
+
+	INSTALLED_APPS = (
+    	...
+    	"ajaxuploader",
+	)
+
+2. Then:
+
+	$ python manage.py collectstatic
+
+Step 3. Include it in your app's views and urls.
 ------------------------------------------------
 You'll need to make sure to meet the csrf requirements to still make valum's uploader work.  Code similar to the following should work:
 
 views.py
 
-	from django.shortcuts import render_to_response
+	from django.shortcuts import render
 	from ajaxuploader.views import AjaxFileUploader
 	from django.middleware.csrf import get_token
 
 	def start(request):
-	    csrf_token = get_token( request )
-		return render_to_response('import.html',
-		                   locals(),
-		                   context_instance=RequestContext(request))
-
+	    csrf_token = get_token(request)
+		return render(request, 'import.html',
+			{'csrf_token': csrf_token})
 
 	import_uploader = AjaxFileUploader()
-
+	
 
 urls.py 
 
-	url( r'ajax-upload$',                     views.import_uploader,             name="my_ajax_upload" ),
+	url( r'ajax-upload$', views.import_uploader, name="my_ajax_upload"),
 
-Step 3. Set up your template.
+Step 4. Set up your template.
 -----------------------------
 This sample is included in the templates directory, but at the minimum, you need:
 
 	<!doctype html> 
 	<head>
-		<script src="{{STATIC_URL}}django-ajax-uploader/fileuploader.js" ></script>
-		<link href="{{STATIC_URL}}django-ajax-uploader/fileuploader.css" media="screen" rel="stylesheet" type="text/css" />
+		<script src="{{ STATIC_URL }}django-ajax-uploader/fileuploader.js" ></script>
+		<link href="{{ STATIC_URL }}django-ajax-uploader/fileuploader.css" media="screen" rel="stylesheet" type="text/css" />
 		<script>
 			var uploader = new qq.FileUploader( {
 			    action: "{% url my_ajax_upload %}",
@@ -82,12 +100,12 @@ This sample is included in the templates directory, but at the minimum, you need
 Backends
 ========
 
-`django-ajax-uploader` can put the uploaded files into a number of places, and perform actions on the files uploaded. Currently, there are backends available for S3 (default) and local storage, as well as a locally stored image thumbnail backend.  Creating a custom backend is fairly straightforward, and pull requests are welcome.
+`django-ajax-uploader` can put the uploaded files into a number of places, and perform actions on the files uploaded. Currently, there are backends available for local storage (default) and Amazon S3, as well as a locally stored image thumbnail backend. Creating a custom backend is fairly straightforward, and pull requests are welcome.
 
 Built-in Backends
 ------------------
 
-`django-ajax-uploader` has following backends:
+`django-ajax-uploader` has the following backends:
 
 ### local.LocalUploadBackend ###
 
@@ -147,7 +165,7 @@ Context returned:
 Backend Usage
 ------------------------
 
-The default backend is `s3.S3UploadBackend`. To use another backend, specify it when instantiating `AjaxFileUploader`.
+The default backend is `local.LocalUploadBackend`. To use another backend, specify it when instantiating `AjaxFileUploader`.
 
 For instance, to use `LocalUploadBackend`:
 

--- a/README.md
+++ b/README.md
@@ -11,11 +11,13 @@ Step 1. Install django-ajax-uploader.
 Right now, you can either:
 
 - Download and install, or
-- `pip install -e git://github.com/GoodCloud/django-ajax-uploader.git#egg=ajaxuploader` it from here. If there's 
+- `pip install -e git://github.com/chrisjones-brack3t/django-ajax-uploader.git#egg=ajaxuploader` it from here. If there's 
 demand, I'll look into pypi.
 - If you plan on using the Amazon S3 backend you will also need to install [boto](https://github.com/boto/boto)
 
-	$ pip install boto
+```
+$ pip install boto
+```
 
 
 Step 2. (Django 1.3 only)
@@ -66,7 +68,7 @@ Step 4. Set up your template.
 -----------------------------
 This sample is included in the templates directory, but at the minimum, you need:
 
-```
+```html
 <!doctype html>
     <head>
         <script src="{{ STATIC_URL }}django-ajax-uploader/fileuploader.js" ></script>
@@ -104,7 +106,7 @@ This sample is included in the templates directory, but at the minimum, you need
     </div>
 </body>
 </html>
-
+```
 
 Backends
 ========

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 It uses valum's great uploader: https://github.com/valums/file-uploader , and draws heavy inspiration and some code from https://github.com/alexkuhl/file-uploader
 
-In short, it implements a callable class, `AjaxFileUploader` that you can use to handle uploads.  By default, `AjaxFileUploader` assumes you want to upload to Amazon's S3, but you can select any other backend if desired or write your own (see backends section below).  Pull requests welcome! 
+In short, it implements a callable class, `AjaxFileUploader` that you can use to handle uploads. By default, `AjaxFileUploader` assumes you want to upload to local storage, but you can select any other backend if desired or write your own (see backends section below). Pull requests welcome!
 
 Usage
 =====
@@ -24,14 +24,18 @@ For Django 1.3 you will need to have the app in your installed apps tuple for co
 
 1. Add 'ajaxuploader' to you installed apps in settings.py
 
-	INSTALLED_APPS = (
-    	...
-    	"ajaxuploader",
-	)
+```
+INSTALLED_APPS = (
+    ...
+    "ajaxuploader",
+)
+```
 
 2. Then:
 
-	$ python manage.py collectstatic
+```
+$ python manage.py collectstatic
+```
 
 Step 3. Include it in your app's views and urls.
 ------------------------------------------------
@@ -39,62 +43,67 @@ You'll need to make sure to meet the csrf requirements to still make valum's upl
 
 views.py
 
-	from django.shortcuts import render
-	from ajaxuploader.views import AjaxFileUploader
-	from django.middleware.csrf import get_token
+```python
+from django.shortcuts import render
+from ajaxuploader.views import AjaxFileUploader
+from django.middleware.csrf import get_token
 
-	def start(request):
-	    csrf_token = get_token(request)
-		return render(request, 'import.html',
-			{'csrf_token': csrf_token})
+def start(request):
+    csrf_token = get_token(request)
+    return render(request, 'import.html',
+        {'csrf_token': csrf_token})
 
-	import_uploader = AjaxFileUploader()
-	
+import_uploader = AjaxFileUploader()
+```	
 
 urls.py 
 
-	url( r'ajax-upload$', views.import_uploader, name="my_ajax_upload"),
+```
+url(r'ajax-upload$', views.import_uploader, name="my_ajax_upload"),
+```
 
 Step 4. Set up your template.
 -----------------------------
 This sample is included in the templates directory, but at the minimum, you need:
 
-	<!doctype html> 
-	<head>
-		<script src="{{ STATIC_URL }}django-ajax-uploader/fileuploader.js" ></script>
-		<link href="{{ STATIC_URL }}django-ajax-uploader/fileuploader.css" media="screen" rel="stylesheet" type="text/css" />
-		<script>
-			var uploader = new qq.FileUploader( {
-			    action: "{% url my_ajax_upload %}",
-			    element: $('#file-uploader')[0],
-			    multiple: true,
-			    onComplete: function( id, fileName, responseJSON ) {
-			      if( responseJSON.success )
-			        alert( "success!" ) ;
-			      else
-			        alert( "upload failed!" ) ;
-			    },
-			    onAllComplete: function( uploads ) {
-			      // uploads is an array of maps
-			      // the maps look like this: { file: FileObject, response: JSONServerResponse }
-			      alert( "All complete!" ) ;
-			    },
-			    params: {
-			      'csrf_token': '{{ csrf_token }}',
-			      'csrf_name': 'csrfmiddlewaretoken',
-			      'csrf_xname': 'X-CSRFToken',
-			    },
-			  }) ;
-		</script>
-	</head>
-	<body>
-		<div id="file-uploader">       
-		    <noscript>          
-		        <p>Please enable JavaScript to use file uploader.</p>
-		    </noscript>         
-		</div>
-	</body>
-	</html>
+```
+<!doctype html>
+    <head>
+        <script src="{{ STATIC_URL }}django-ajax-uploader/fileuploader.js" ></script>
+        <link href="{{ STATIC_URL }}django-ajax-uploader/fileuploader.css" media="screen" rel="stylesheet" type="text/css" />
+        <script>
+            var uploader = new qq.FileUploader({
+                action: "{% url my_ajax_upload %}",
+                element: $('#file-uploader')[0],
+                multiple: true,
+                onComplete: function(id, fileName, responseJSON) {
+                    if(responseJSON.success) {
+                        alert("success!");
+                    } else {
+                        alert("upload failed!");
+                    }
+                },
+                onAllComplete: function(uploads) {
+                    // uploads is an array of maps
+                    // the maps look like this: {file: FileObject, response: JSONServerResponse}
+                    alert("All complete!");
+                },
+                params: {
+                    'csrf_token': '{{ csrf_token }}',
+                    'csrf_name': 'csrfmiddlewaretoken',
+                    'csrf_xname': 'X-CSRFToken',
+                },
+            });
+        </script>
+    </head>
+<body>
+    <div id="file-uploader">       
+        <noscript>          
+            <p>Please enable JavaScript to use file uploader.</p>
+        </noscript>         
+    </div>
+</body>
+</html>
 
 
 Backends

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 `django-ajax-uploader` provides a useful class you can use to easily implement ajax uploads.
 
-It uses valum's great uploader: https://github.com/valums/file-uploader , and draws heavy inspiration and some code from https://github.com/alexkuhl/file-uploader
+It uses valum's great uploader: https://github.com/valums/file-uploader, and draws heavy inspiration and some code from 
+https://github.com/alexkuhl/file-uploader
 
 In short, it implements a callable class, `AjaxFileUploader` that you can use to handle uploads. By default, `AjaxFileUploader` assumes you want to upload to local storage, but you can select any other backend if desired or write your own (see backends section below). Pull requests welcome!
 
@@ -17,6 +18,12 @@ demand, I'll look into pypi.
 
 ```
 $ pip install boto
+```
+
+- If you plan on using the MongoDB GridFS backend you will also need to install [pymongo](https://github.com/AloneRoad/pymongo)
+
+```
+$ pip install pymongo
 ```
 
 
@@ -111,7 +118,9 @@ This sample is included in the templates directory, but at the minimum, you need
 Backends
 ========
 
-`django-ajax-uploader` can put the uploaded files into a number of places, and perform actions on the files uploaded. Currently, there are backends available for local storage (default) and Amazon S3, as well as a locally stored image thumbnail backend. Creating a custom backend is fairly straightforward, and pull requests are welcome.
+`django-ajax-uploader` can put the uploaded files into a number of places, and perform actions on the files uploaded. Currently, 
+there are backends available for local storage (default), Amazon S3 and MongoDB (GridFS), as well as a locally stored image 
+thumbnail backend. Creating a custom backend is fairly straightforward, and pull requests are welcome.
 
 Built-in Backends
 ------------------
@@ -134,6 +143,30 @@ Settings:
 Context returned:
 
 * `path`: The full media path to the uploaded file.
+
+
+### mongodb.MongoDBUploadBackend ###
+
+Stores the file in MongoDB via GridFS
+
+Requirements
+
+* [pymongo](https://github.com/AloneRoad/pymongo)
+
+Settings:
+
+* `AJAXUPLOAD_MONGODB_HOST`: Specify the host of your MongoDB server. Defaults to localhost if not specified.
+* `AJAXUPLOAD_MONGODB_PORT`: Specify the port of your MongoDB server. Defaults to 27017 if not specified.
+
+Arguments
+
+* db (required): Specify the database within MongoDB you wish to use
+* collection (optional): Specify the collection within the db you wish to use. This is optional and will default to `fs` if not specified
+
+
+Context returned:
+
+* None
 
 
 ### s3.S3UploadBackend ###
@@ -178,15 +211,17 @@ Backend Usage
 
 The default backend is `local.LocalUploadBackend`. To use another backend, specify it when instantiating `AjaxFileUploader`.
 
-For instance, to use `LocalUploadBackend`:
+For instance, to use `MongoDBUploadBackend`:
 
 views.py
 
-    from ajaxuploader.backends.local import LocalUploadBackend
+```python
+from ajaxuploader.views import AjaxFileUploader
+from ajaxuploader.backends.mongodb import MongoDBUploadBackend
 
-    ...
-    import_uploader = AjaxFileUploader(backend=LocalUploadBackend)
-
+...
+import_uploader = AjaxFileUploader(backend=MongoDBUploadBackend, db='uploads')
+```
 
 To set custom parameters, simply pass them along with instantiation.  For example, for larger thumbnails, preserving the originals:
 views.py

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Step 2. (Django 1.3 only)
 -------------------------
 For Django 1.3 you will need to have the app in your installed apps tuple for collect static to pick up the files.
 
-1. Add 'ajaxuploader' to you installed apps in settings.py
+First Add 'ajaxuploader' to you installed apps in settings.py
 
 ```
 INSTALLED_APPS = (
@@ -31,7 +31,7 @@ INSTALLED_APPS = (
 )
 ```
 
-2. Then:
+Then:
 
 ```
 $ python manage.py collectstatic

--- a/ajaxuploader/backends/local.py
+++ b/ajaxuploader/backends/local.py
@@ -1,6 +1,5 @@
 from io import FileIO, BufferedWriter
 import os
-from StringIO import StringIO
 
 from django.conf import settings
 
@@ -16,7 +15,7 @@ class LocalUploadBackend(AbstractUploadBackend):
             os.makedirs(os.path.realpath(os.path.dirname(self._path)))
         except:
             pass
-        self._dest = BufferedWriter(FileIO(self._path, "wb"))
+        self._dest = BufferedWriter(FileIO(self._path, "w"))
 
     def upload_chunk(self, chunk):
         self._dest.write(chunk)

--- a/ajaxuploader/backends/mongodb.py
+++ b/ajaxuploader/backends/mongodb.py
@@ -1,3 +1,5 @@
+import mimetypes
+
 from django.conf import settings
 
 from pymongo import Connection
@@ -9,17 +11,37 @@ class MongoDBUploadBackend(AbstractUploadBackend):
 
     def __init__(self, *args, **kwargs):
         self.db = kwargs.pop('db')
-        self.collection = kwargs.pop('collection')
+
+        try:
+            self.collection = kwargs.pop('collection')
+        except KeyError:
+            self.collection = None
+
+        super(MongoDBUploadBackend, self).__init__(*args, **kwargs)
+
+    def setup(self, filename, encoding='UTF-8'):
+        """
+        Setup MongoDB connection to specified db. Collection is optional
+        and will default to fs if not specified.
+
+        Create new gridFS file which returns a GridIn instance to write
+        data to.
+        """
         self.connection = Connection(
             host=getattr(settings, 'AJAXUPLOAD_MONGODB_HOST', 'localhost'),
             port=getattr(settings, 'AJAXUPLOAD_MONGODB_PORT', 27017)
         )[self.db]
-        self.grid = gridfs.GridFS(self.connection, collection=self.collection)
-        super(MongoDBUploadBackend, self).__init__(*args, **kwargs)
 
-    def setup(self, filename):
+        if self.collection:
+            self.grid = gridfs.GridFS(self.connection,
+                collection=self.collection)
+        else:
+            self.grid = gridfs.GridFS(self.connection)
+
         self._path = filename
-        self.f = self.grid.new_file(**{'filename': self._path})
+        content_type, encoding = mimetypes.guess_type(filename)
+        self.f = self.grid.new_file(**{'filename': self._path,
+            'encoding': 'UTF-8', 'content_type': content_type})
 
     def upload_chunk(self, chunk):
         self.f.write(chunk)

--- a/ajaxuploader/backends/mongodb.py
+++ b/ajaxuploader/backends/mongodb.py
@@ -1,0 +1,28 @@
+from django.conf import settings
+
+from pymongo import Connection
+import gridfs
+
+from ajaxuploader.backends.base import AbstractUploadBackend
+
+class MongoDBUploadBackend(AbstractUploadBackend):
+
+    def __init__(self, *args, **kwargs):
+        self.db = kwargs.pop('db')
+        self.collection = kwargs.pop('collection')
+        self.connection = Connection(
+            host=getattr(settings, 'AJAXUPLOAD_MONGODB_HOST', 'localhost'),
+            port=getattr(settings, 'AJAXUPLOAD_MONGODB_PORT', 27017)
+        )[self.db]
+        self.grid = gridfs.GridFS(self.connection, collection=self.collection)
+        super(MongoDBUploadBackend, self).__init__(*args, **kwargs)
+
+    def setup(self, filename):
+        self._path = filename
+        self.f = self.grid.new_file(**{'filename': self._path})
+
+    def upload_chunk(self, chunk):
+        self.f.write(chunk)
+
+    def upload_complete(self, request, filename):
+        self.f.close()

--- a/ajaxuploader/views.py
+++ b/ajaxuploader/views.py
@@ -1,19 +1,20 @@
-from django.http import HttpResponse, HttpResponseBadRequest, Http404
 import json
 
-from ajaxuploader.backends.s3 import S3UploadBackend
+from django.http import HttpResponse, HttpResponseBadRequest, Http404
+
+from ajaxuploader.backends.local import LocalUploadBackend
 
 class AjaxFileUploader(object):
     def __init__(self, backend=None, **kwargs):
         if backend is None:
-            backend = S3UploadBackend
+            backend = LocalUploadBackend
         self._backend = backend(**kwargs)
 
     def __call__(self,request):
         return self._ajax_upload(request)
 
     def _ajax_upload(self, request):
-        if request.method == "POST":        
+        if request.method == "POST":
             if request.is_ajax():
                 # the file is stored raw in the request
                 upload = request
@@ -22,7 +23,7 @@ class AjaxFileUploader(object):
                 # is the "advanced" ajax upload
                 try:
                     filename = request.GET['qqfile']
-                except KeyError: 
+                except KeyError:
                     return HttpResponseBadRequest("AJAX request not valid")
             # not an ajax upload, so it was the "basic" iframe version with
             # submission via form


### PR DESCRIPTION
We changed the default backend to be LocalUploadBackend. Reason for this is that boto is required for the S3 backend to work. Local uploads work without any requirements so it seems to be the safest default. Also changed the BufferedWriter (local upload) mode to `w` from `wb` which should make it work more places.

Added in a MongoDB backend which uses GridFS. Also added in a couple of new settings which left unspecified will default to Mongo's default host/port settings. When we end up implementing authentication to our system we'll add authentication support to the MongoDB backend as well.

Cleaned up and added to the README. Also added MongoDB backend documentation.

The backend could use more testing but so far it's working quite well for us at the moment. As we build this out I'm sure we'll have more pull requests coming your way.

Authors
- [Chris Jones](https://github.com/chrisjones-brack3t/)
- [Kenneth Love](https://github.com/kennethlove)
