### PR TITLE
Created a base class that doesn't return an HttpResponse object

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,29 @@ url(r'start$', views.start, name="start"),
 url(r'ajax-upload$', views.import_uploader, name="my_ajax_upload"),
 ```
 
+Or if you want to perform some pre-/post-processing on the ajax requests, you can use code similar to below:
+
+views.py
+
+```python
+@login_required
+def ajax_upload(request):
+    # confirm that this user is permitted to upload files
+    # ....
+    
+    # handle the upload using BaseAjaxFileUploader. We'll need to convert it
+    # to json later ourselves before returning it.
+    uploader = BaseAjaxFileUploader()
+    upload_response = uploader(request)
+    
+    if upload_response['success'] == True:
+    	# if the upload was successful, do something like save the path in a model
+    	# The filename is in upload_response['filename']
+    
+    # return the response as JSON
+    return HttpResponse(json.dumps(upload_response, cls=DjangoJSONEncoder))
+```
+
 Step 4. Set up your template.
 -----------------------------
 This sample is included in the templates directory, but at the minimum, you need:

--- a/ajaxuploader/views.py
+++ b/ajaxuploader/views.py
@@ -5,7 +5,7 @@ from django.http import HttpResponse, HttpResponseBadRequest, Http404
 
 from ajaxuploader.backends.local import LocalUploadBackend
 
-class RawAjaxFileUploader(object):
+class BaseAjaxFileUploader(object):
     """
     Performs an upload via AJAX then returns a dictionary which can be 
     processed further on the server side.
@@ -65,9 +65,9 @@ class RawAjaxFileUploader(object):
 
             return ret_json
 
-class AjaxFileUploader(RawAjaxFileUploader):
+class AjaxFileUploader(BaseAjaxFileUploader):
     """
-    Subclass of RawAjaxFileUploader that serialises the response from the
+    Subclass of BaseAjaxFileUploader that serialises the response from the
     upload and returns it as an HttpResponse.
     """
     def _ajax_upload(self, request):

--- a/ajaxuploader/views.py
+++ b/ajaxuploader/views.py
@@ -5,7 +5,11 @@ from django.http import HttpResponse, HttpResponseBadRequest, Http404
 
 from ajaxuploader.backends.local import LocalUploadBackend
 
-class AjaxFileUploader(object):
+class RawAjaxFileUploader(object):
+    """
+    Performs an upload via AJAX then returns a dictionary which can be 
+    processed further on the server side.
+    """
     def __init__(self, backend=None, **kwargs):
         if backend is None:
             backend = LocalUploadBackend
@@ -59,4 +63,13 @@ class AjaxFileUploader(object):
             if extra_context is not None:
                 ret_json.update(extra_context)
 
-            return HttpResponse(json.dumps(ret_json, cls=DjangoJSONEncoder))
+            return ret_json
+
+class AjaxFileUploader(RawAjaxFileUploader):
+    """
+    Subclass of RawAjaxFileUploader that serialises the response from the
+    upload and returns it as an HttpResponse.
+    """
+    def _ajax_upload(self, request):
+        ret_json = super(AjaxFileUploader, self)._ajax_upload(request)
+        return HttpResponse(json.dumps(ret_json, cls=DjangoJSONEncoder))


### PR DESCRIPTION
I've created a new class called RawAjaxFileUploader which just performs the upload and returns the response dictionary to the client code. This allows extra server-side processing (such as saving the path the uploaded file in the database).

AjaxFileUploader is a subclass of this class which behaves exactly as it used to, returning the response serialised and wrapped in an HttpResponse object.
