### PR TITLE
Very small fix for multiple file upload vie dropzone

### DIFF
--- a/ajaxuploader/static/ajaxuploader/js/fileuploader.js
+++ b/ajaxuploader/static/ajaxuploader/js/fileuploader.js
@@ -601,7 +601,7 @@ qq.extend(qq.FileUploader.prototype, {
             onDrop: function(e){
                 dropArea.style.display = 'none';
                 qq.removeClass(dropArea, self._classes.dropActive);
-                if( !self.multiple && e.dataTransfer.files.length > 1 )
+                if( !self._options.multiple && e.dataTransfer.files.length > 1 )
                     alert( "Multiple file uploads are disabled." ) ;
                 else
                     self._uploadFileList(e.dataTransfer.files);    


### PR DESCRIPTION
When user trying to upload multiple files by dragging it to dropzone script alerts "Multiple file uploads are disabled." even if "multiple" option is true because of wrong variable name.
