### PR TITLE
MongoDB Backend now supports Replicaset connections.

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,8 +175,19 @@ Requirements
 
 Settings:
 
-* `AJAXUPLOAD_MONGODB_HOST`: Specify the host of your MongoDB server. Defaults to localhost if not specified.
-* `AJAXUPLOAD_MONGODB_PORT`: Specify the port of your MongoDB server. Defaults to 27017 if not specified.
+* `AJAXUPLOAD_MONGODB_HOST`: Specify either a single host:port or a list of host:port. Defaults to `"localhost:27017"`
+* `AJAXUPLOAD_MONGODB_PORT` (for backwards compatibility): Specify the port of your MongoDB server. Defaults to 27017 if not specified.
+* `AJAXUPLOAD_MONGODB_REPLICASET` (optional): Specify the name of your replicaset as a string. Defaults to an empty string.
+
+```python
+
+# Replicaset
+AJAXUPLOAD_MONGODB_HOST = ["127.0.0.1:27017", "127.0.0.1:27018"]
+AJAXUPLOAD_MONGODB_REPLICASET = "myset"
+
+# Standard
+AJASUPLOAD_MONGODB_HOST = "127.0.0.1:27017"
+```
 
 Arguments
 

--- a/ajaxuploader/backends/mongodb.py
+++ b/ajaxuploader/backends/mongodb.py
@@ -34,18 +34,17 @@ class MongoDBUploadBackend(AbstractUploadBackend):
         """
         host = getattr(settings, "AJAXUPLOAD_MONGODB_HOST", "localhost:27017")
         port = getattr(settings, "AJAXUPLOAD_MONGODB_PORT", 27017)
-        replicaset = getattr(settings, "AJAXUPLOAD_MONGODB_REPLICATSET", None)
+        replicaset = getattr(settings, "AJAXUPLOAD_MONGODB_REPLICATSET", "")
 
         if isinstance(host, list):
             host = ", ".join(host)
-            self.connection = Connection(host, replicaset=replicaset)[self.db]
         else:
             if not ":" in host:
                 """
                 Backwards compatibility for old version.
                 """
                 host = u"%s:%d" % (host, port)
-            self.connection = Connection(host)[self.db]
+        self.connection = Connection(host, replicaset=replicaset)[self.db]
 
         if self.collection:
             self.grid = gridfs.GridFS(self.connection,

--- a/ajaxuploader/backends/mongodb.py
+++ b/ajaxuploader/backends/mongodb.py
@@ -7,8 +7,13 @@ import gridfs
 
 from ajaxuploader.backends.base import AbstractUploadBackend
 
-class MongoDBUploadBackend(AbstractUploadBackend):
 
+class MongoDBUploadBackend(AbstractUploadBackend):
+    """
+    Stores uploaded file in Mongo's GridFS.
+
+    Requirements: pymongo
+    """
     def __init__(self, *args, **kwargs):
         self.db = kwargs.pop('db')
 
@@ -27,10 +32,13 @@ class MongoDBUploadBackend(AbstractUploadBackend):
         Create new gridFS file which returns a GridIn instance to write
         data to.
         """
-        self.connection = Connection(
-            host=getattr(settings, 'AJAXUPLOAD_MONGODB_HOST', 'localhost'),
-            port=getattr(settings, 'AJAXUPLOAD_MONGODB_PORT', 27017)
-        )[self.db]
+        host = getattr(settings, "AJAXUPLOAD_MONGODB_HOST", "localhost:27017")
+        replicaset = getattr(settings, "AJAXUPLOAD_MONGODB_REPLICATSET", None)
+
+        if isinstance(host, list):
+            host = ", ".join(host)
+
+        self.connection = Connection(host, replicaset=replicaset)[self.db]
 
         if self.collection:
             self.grid = gridfs.GridFS(self.connection,

--- a/ajaxuploader/backends/mongodb.py
+++ b/ajaxuploader/backends/mongodb.py
@@ -33,12 +33,19 @@ class MongoDBUploadBackend(AbstractUploadBackend):
         data to.
         """
         host = getattr(settings, "AJAXUPLOAD_MONGODB_HOST", "localhost:27017")
+        port = getattr(settings, "AJAXUPLOAD_MONGODB_PORT", 27017)
         replicaset = getattr(settings, "AJAXUPLOAD_MONGODB_REPLICATSET", None)
 
         if isinstance(host, list):
             host = ", ".join(host)
-
-        self.connection = Connection(host, replicaset=replicaset)[self.db]
+            self.connection = Connection(host, replicaset=replicaset)[self.db]
+        else:
+            if not ":" in host:
+                """
+                Backwards compatibility for old version.
+                """
+                host = u"%s:%d" % (host, port)
+            self.connection = Connection(host)[self.db]
 
         if self.collection:
             self.grid = gridfs.GridFS(self.connection,

--- a/ajaxuploader/backends/mongodb.py
+++ b/ajaxuploader/backends/mongodb.py
@@ -34,7 +34,7 @@ class MongoDBUploadBackend(AbstractUploadBackend):
         """
         host = getattr(settings, "AJAXUPLOAD_MONGODB_HOST", "localhost:27017")
         port = getattr(settings, "AJAXUPLOAD_MONGODB_PORT", 27017)
-        replicaset = getattr(settings, "AJAXUPLOAD_MONGODB_REPLICATSET", "")
+        replicaset = getattr(settings, "AJAXUPLOAD_MONGODB_REPLICASET", "")
 
         if isinstance(host, list):
             host = ", ".join(host)


### PR DESCRIPTION
Handles replicaset connections and is still backwards compatible with previous settings.
