### PR TITLE
Added content_type to the HttpResponse

### DIFF
--- a/ajaxuploader/views.py
+++ b/ajaxuploader/views.py
@@ -59,4 +59,4 @@ class AjaxFileUploader(object):
             if extra_context is not None:
                 ret_json.update(extra_context)
 
-            return HttpResponse(json.dumps(ret_json, cls=DjangoJSONEncoder))
+            return HttpResponse(json.dumps(ret_json, cls=DjangoJSONEncoder), content_type='application/json; charset=utf-8')


### PR DESCRIPTION
I'm running into a problem where adding extra_context to the response works fine, but if the extra context includes characters like " or ' (e.g. it includes html with tags like <div id="some-div">), the responseJSON comes empty javascript Object(), even if the JSON is valid (the ' and " are escaped correctly).

I thought it had to do with the content_type not being set, but that didn't resolve the problem, but it doesn't hurt to explicitly set the content_type! 

Any thoughts on the original problem are appreciated. 
