### PR TITLE
added args & kwargs to __call__ due to possible url parameter 

### DIFF
--- a/ajaxuploader/backends/base.py
+++ b/ajaxuploader/backends/base.py
@@ -4,34 +4,34 @@ class AbstractUploadBackend(object):
     def __init__(self, **kwargs):
         self.__dict__.update(kwargs)
 
-    def setup(self, filename):
+    def setup(self, filename, *args, **kwargs):
         """Responsible for doing any pre-processing needed before the upload
         starts."""
 
-    def update_filename(self, request, filename):
+    def update_filename(self, request, filename, *args, **kwargs):
         """Returns a new name for the file being uploaded."""
 
-    def upload_chunk(self, chunk):
+    def upload_chunk(self, chunk, *args, **kwargs):
         """Called when a string was read from the client, responsible for 
         writing that string to the destination file."""
         raise NotImplementedError
 
-    def upload_complete(self, request, filename):
+    def upload_complete(self, request, filename, *args, **kwargs):
         """Overriden to performs any actions needed post-upload, and returns
         a dict to be added to the render / json context"""
 
-    def upload(self, uploaded, filename, raw_data):
+    def upload(self, uploaded, filename, raw_data, *args, **kwargs):
         try:
             if raw_data:
                 # File was uploaded via ajax, and is streaming in.
                 chunk = uploaded.read(self.BUFFER_SIZE)
                 while len(chunk) > 0:
-                    self.upload_chunk(chunk)
+                    self.upload_chunk(chunk, *args, **kwargs)
                     chunk = uploaded.read(self.BUFFER_SIZE)
             else:
                 # File was uploaded via a POST, and is here.
                 for chunk in uploaded.chunks():
-                    self.upload_chunk(chunk)
+                    self.upload_chunk(chunk, *args, **kwargs)
             return True
         except:
             # things went badly.

--- a/ajaxuploader/backends/couch.py
+++ b/ajaxuploader/backends/couch.py
@@ -33,17 +33,17 @@ class CouchDBUploadBackend(AbstractUploadBackend):
         
         super(CouchDBUploadBackend, self).__init__(*args, **kwargs)
 
-    def setup(self, filename):
+    def setup(self, filename, *args, **kwargs):
         self.connection = Server(getattr(settings,
                                          'AJAXUPLOAD_COUCHDB_HOST',
                                          'http://localhost:5984')
         )[self.database]
         self._dest = TemporaryFile()
 
-    def upload_chunk(self, chunk):
+    def upload_chunk(self, chunk, *args, **kwargs):
         self._dest.write(chunk)
 
-    def upload_complete(self, request, filename):
+    def upload_complete(self, request, filename, *args, **kwargs):
         self._dest.seek(0)
         doc_id = uuid4().hex
         # create doc by self defined uuid. We need the _rev for attachment

--- a/ajaxuploader/backends/default_storage.py
+++ b/ajaxuploader/backends/default_storage.py
@@ -15,7 +15,7 @@ class DefaultStorageUploadBackend(AbstractUploadBackend):
     
     UPLOAD_DIR = 'uploads'
 
-    def setup(self, filename):
+    def setup(self, filename, *args, **kwargs):
         # join UPLOAD_DIR with filename 
         new_path = os.path.join(self.UPLOAD_DIR, filename)
 
@@ -25,9 +25,9 @@ class DefaultStorageUploadBackend(AbstractUploadBackend):
         # create BufferedWriter for new file
         self._dest = default_storage.open(self.path, mode='wb')
 
-    def upload_chunk(self, chunk):
+    def upload_chunk(self, chunk, *args, **kwargs):
         self._dest.write(chunk)
 
-    def upload_complete(self, request, filename):
+    def upload_complete(self, request, filename, *args, **kwargs):
         self._dest.close()
         return {"path": self.path}

--- a/ajaxuploader/backends/local.py
+++ b/ajaxuploader/backends/local.py
@@ -9,7 +9,7 @@ from ajaxuploader.backends.base import AbstractUploadBackend
 class LocalUploadBackend(AbstractUploadBackend):
     UPLOAD_DIR = "uploads"
 
-    def setup(self, filename):
+    def setup(self, filename, *args, **kwargs):
         self._path = os.path.join(
             settings.MEDIA_ROOT, self.UPLOAD_DIR, filename)
         try:
@@ -18,15 +18,15 @@ class LocalUploadBackend(AbstractUploadBackend):
             pass
         self._dest = BufferedWriter(FileIO(self._path, "w"))
 
-    def upload_chunk(self, chunk):
+    def upload_chunk(self, chunk, *args, **kwargs):
         self._dest.write(chunk)
 
-    def upload_complete(self, request, filename):
+    def upload_complete(self, request, filename, *args, **kwargs):
         path = settings.MEDIA_URL + self.UPLOAD_DIR + "/" + filename
         self._dest.close()
         return {"path": path}
 
-    def update_filename(self, request, filename):
+    def update_filename(self, request, filename, *args, **kwargs):
         """
         Returns a new name for the file being uploaded.
         Ensure file with name doesn't exist, and if it does,

--- a/ajaxuploader/backends/mongodb.py
+++ b/ajaxuploader/backends/mongodb.py
@@ -24,7 +24,7 @@ class MongoDBUploadBackend(AbstractUploadBackend):
 
         super(MongoDBUploadBackend, self).__init__(*args, **kwargs)
 
-    def setup(self, filename, encoding='UTF-8'):
+    def setup(self, filename, encoding='UTF-8', *args, **kwargs):
         """
         Setup MongoDB connection to specified db. Collection is optional
         and will default to fs if not specified.
@@ -57,8 +57,8 @@ class MongoDBUploadBackend(AbstractUploadBackend):
         self.f = self.grid.new_file(**{'filename': self._path,
             'encoding': 'UTF-8', 'content_type': content_type})
 
-    def upload_chunk(self, chunk):
+    def upload_chunk(self, chunk, *args, **kwargs):
         self.f.write(chunk)
 
-    def upload_complete(self, request, filename):
+    def upload_complete(self, request, filename, *args, **kwargs):
         self.f.close()

--- a/ajaxuploader/backends/s3.py
+++ b/ajaxuploader/backends/s3.py
@@ -9,7 +9,7 @@ from ajaxuploader.backends.base import AbstractUploadBackend
 class S3UploadBackend(AbstractUploadBackend):
     NUM_PARALLEL_PROCESSES = 4
 
-    def upload_chunk(self, chunk):
+    def upload_chunk(self, chunk, *args, **kwargs):
         self._counter += 1
         buffer = StringIO()
         buffer.write(chunk)
@@ -18,7 +18,7 @@ class S3UploadBackend(AbstractUploadBackend):
         buffer.close()
         
 
-    def setup(self, filename):
+    def setup(self, filename, *args, **kwargs):
         self._bucket = boto.connect_s3(settings.AWS_ACCESS_KEY_ID,
                                        settings.AWS_SECRET_ACCESS_KEY)\
                             .lookup(settings.AWS_BUCKET_NAME)
@@ -26,7 +26,7 @@ class S3UploadBackend(AbstractUploadBackend):
         self._pool = Pool(processes=self.NUM_PARALLEL_PROCESSES)
         self._counter = 0
 
-    def upload_complete(self, request, filename):
+    def upload_complete(self, request, filename, *args, **kwargs):
         # Tie up loose ends, and finish the upload
         self._pool.close()
         self._pool.join()

--- a/ajaxuploader/backends/thumbnail.py
+++ b/ajaxuploader/backends/thumbnail.py
@@ -9,7 +9,7 @@ class ThumbnailUploadBackend(LocalUploadBackend):
     DIMENSIONS = "100x100"
     KEEP_ORIGINAL = False
 
-    def upload_complete(self, request, filename):
+    def upload_complete(self, request, filename, *args, **kwargs):
         thumbnail = get_thumbnail(self._path, self.DIMENSIONS)
         if not self.KEEP_ORIGINAL:
             os.unlink(self._path)

--- a/ajaxuploader/views.py
+++ b/ajaxuploader/views.py
@@ -12,9 +12,9 @@ class AjaxFileUploader(object):
         self.get_backend = lambda: backend(**kwargs)
 
     def __call__(self, request, *args, **kwargs):
-        return self._ajax_upload(request)
+        return self._ajax_upload(request, *args, **kwargs)
 
-    def _ajax_upload(self, request):
+    def _ajax_upload(self, request, *args, **kwargs):
         if request.method == "POST":
             if request.is_ajax():
                 # the file is stored raw in the request
@@ -46,13 +46,13 @@ class AjaxFileUploader(object):
             backend = self.get_backend()
 
             # custom filename handler
-            filename = (backend.update_filename(request, filename)
+            filename = (backend.update_filename(request, filename, *args, **kwargs)
                         or filename)
             # save the file
-            backend.setup(filename)
-            success = backend.upload(upload, filename, is_raw)
+            backend.setup(filename, *args, **kwargs)
+            success = backend.upload(upload, filename, is_raw, *args, **kwargs)
             # callback
-            extra_context = backend.upload_complete(request, filename)
+            extra_context = backend.upload_complete(request, filename, *args, **kwargs)
 
             # let Ajax Upload know whether we saved it or not
             ret_json = {'success': success, 'filename': filename}

--- a/ajaxuploader/views.py
+++ b/ajaxuploader/views.py
@@ -11,7 +11,7 @@ class AjaxFileUploader(object):
             backend = LocalUploadBackend
         self.get_backend = lambda: backend(**kwargs)
 
-    def __call__(self,request):
+    def __call__(self, request, *args, **kwargs):
         return self._ajax_upload(request)
 
     def _ajax_upload(self, request):


### PR DESCRIPTION
urls like:

url(r'^album/(?P<slug>[-\w]+)/ajax-upload/$', ajax_upload,
name="ajax_upload"),

cannot be used without kwargs in **call**
