### PR TITLE
Add the Easy_Thumbnails backend and updated the README about it. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,26 @@ Context returned:
 
 * `path`: The full media path to the uploaded file.
 
+### easy_thumbnails.EasyThumbnailUploadBackend ###
+
+Stores a thumbnail of the locally, optionally discarding the upload. Uses 'Easy Thumbnails' rather than sorl-thumbnail,
+which requires a key-value store. Subclasses `LocalUploadBackend`.
+
+Requirements:
+
+* [easy-thumbnails](https://github.com/SmileyChris/easy-thumbnails/)
+
+Settings:
+
+* `DIMENSIONS` : A tuple of the dimensions (WxH) to resize the uploaded image to. Defaults to "100x100"
+* `KEEP_ORIGINAL`: Whether to keep the originally uploaded file. Defaults to False.
+* `CROP`: Whether to create a 'cropped' version of the thumbnail. Defaults to True. 
+* `BUFFER_SIZE`: The size of each chunk to write. Defaults to 10 MB.
+
+Context returned:
+
+* `path`: The full media path to the uploaded file.
+
 
 ### default_storage.DefaultStorageUploadBackend ###
 

--- a/ajaxuploader/backends/easy_thumbnails.py
+++ b/ajaxuploader/backends/easy_thumbnails.py
@@ -1,0 +1,21 @@
+import os
+
+from django.conf import settings
+from easy_thumbnails.files import get_thumbnailer
+
+from ajaxuploader.backends.local import LocalUploadBackend
+
+class EasyThumbnailUploadBackend(LocalUploadBackend):
+    DIMENSIONS = (100,000)
+    CROP = True
+    KEEP_ORIGINAL = False
+
+    def upload_complete(self, request, filename):
+
+        options = {'size': self.DIMENSIONS, 'crop': self.CROP}
+        thumb = get_thumbnailer(self._path).get_thumbnail(options)
+
+        if not self.KEEP_ORIGINAL:
+            os.unlink(self._path)
+
+        return {"path": settings.MEDIA_URL + os.path.split(thumb.path)[1]}


### PR DESCRIPTION
easy-thumbnails is another thumbnailer which doesn't require a Key-Value store and also has automatic support for cropping.

This adds an easy_thumbnails backend. Requires easy-thumbnails.
