### PR TITLE
Directory traversal vulnerability Fix

### DIFF
--- a/ajaxuploader/backends/local.py
+++ b/ajaxuploader/backends/local.py
@@ -32,6 +32,7 @@ class LocalUploadBackend(AbstractUploadBackend):
         Ensure file with name doesn't exist, and if it does,
         create a unique filename to avoid overwriting
         """
+        filename = os.path.basename(filename)
         self._dir = os.path.join(
             settings.MEDIA_ROOT, self.UPLOAD_DIR)
         unique_filename = False


### PR DESCRIPTION
django-ajax-uploader have a vulnerability in the local backend when uploading a file, allowing a malicious user to upload to any directory within the ownership of the user running the webapp.
This fix closes that issue getting only a cleaned name ( so , things like '../../filename.jpg', will not work anymore)
