### PR TITLE
Fixes a bug in IE where the returned AJAX is asked to be downloaded

### DIFF
--- a/ajaxuploader/views.py
+++ b/ajaxuploader/views.py
@@ -59,4 +59,5 @@ class AjaxFileUploader(object):
             if extra_context is not None:
                 ret_json.update(extra_context)
 
-            return HttpResponse(json.dumps(ret_json, cls=DjangoJSONEncoder), content_type='application/json; charset=utf-8')
+            # although "application/json" is the correct content type, IE throws a fit
+            return HttpResponse(json.dumps(ret_json, cls=DjangoJSONEncoder), content_type='text/html; charset=utf-8')


### PR DESCRIPTION
Setting content type to application/json, even though correct, causes problems in IE:
https://github.com/valums/file-uploader/blob/master/readme.md

text/html produced the best results for me. Was getting an error with the recommended text/plain
