### PR TITLE
Don't 500 for a GET request to _ajax_upload

### DIFF
--- a/ajaxuploader/views.py
+++ b/ajaxuploader/views.py
@@ -61,3 +61,5 @@ class AjaxFileUploader(object):
 
             # although "application/json" is the correct content type, IE throws a fit
             return HttpResponse(json.dumps(ret_json, cls=DjangoJSONEncoder), content_type='text/html; charset=utf-8')
+        else:
+            return HttpResponseBadRequest("Only POST requests accepted")

--- a/ajaxuploader/views.py
+++ b/ajaxuploader/views.py
@@ -1,7 +1,7 @@
 from django.utils import simplejson as json
 from django.core.serializers.json import DjangoJSONEncoder
 
-from django.http import HttpResponse, HttpResponseBadRequest, Http404
+from django.http import HttpResponse, HttpResponseBadRequest, Http404, HttpResponseNotAllowed
 
 from ajaxuploader.backends.local import LocalUploadBackend
 
@@ -62,4 +62,6 @@ class AjaxFileUploader(object):
             # although "application/json" is the correct content type, IE throws a fit
             return HttpResponse(json.dumps(ret_json, cls=DjangoJSONEncoder), content_type='text/html; charset=utf-8')
         else:
-            return HttpResponseBadRequest("Only POST requests accepted")
+            response = HttpResponseNotAllowed(['POST'])
+            response.write("ERROR: Only POST allowed")
+            return response


### PR DESCRIPTION
Since GoogleBot is getting smarter about crawling AJAX methods, need to ensure trying to access ajax_upload via GET doesn't 500. Instead returns a proper 405 with allowed methods set.
