### PR TITLE
Using Python 2.6's json for Django 1.5 compatibility

### DIFF
--- a/ajaxuploader/views.py
+++ b/ajaxuploader/views.py
@@ -1,4 +1,7 @@
-from django.utils import simplejson as json
+try:
+    import json
+except ImportError:
+    from django.utils import simplejson as json
 from django.core.serializers.json import DjangoJSONEncoder
 
 from django.http import HttpResponse, HttpResponseBadRequest, Http404, HttpResponseNotAllowed


### PR DESCRIPTION
Using simplejson breaks with Django 1.5+. Using Python 2.6's `json`
