### PR TITLE
callable UPLOAD_DIR

### DIFF
--- a/ajaxuploader/backends/default_storage.py
+++ b/ajaxuploader/backends/default_storage.py
@@ -1,4 +1,5 @@
 import os
+import datetime
 
 from django.core.files.storage import default_storage
 from django.core.files.base import ContentFile
@@ -15,9 +16,14 @@ class DefaultStorageUploadBackend(AbstractUploadBackend):
     
     UPLOAD_DIR = 'uploads'
 
+    def get_upload_dir(self):
+        if callable(self.UPLOAD_DIR):
+            return self.UPLOAD_DIR()
+        return datetime.datetime.now().strftime(self.UPLOAD_DIR)
+
     def setup(self, filename, *args, **kwargs):
         # join UPLOAD_DIR with filename 
-        new_path = os.path.join(self.UPLOAD_DIR, filename)
+        new_path = os.path.join(self.get_upload_dir(), filename)
 
         # save empty file in default storage with path = new_path
         self.path = default_storage.save(new_path, ContentFile(''))


### PR DESCRIPTION
This modifies the way the 'UPLOAD_DIR' property is handled by the `DefaultStorageUploadBackend` to make it more similar to Django FileFiels `upload_to` option.

enables the following patterns:

```
# views.py

from ajaxuploader.views import AjaxFileUploader
from ajaxuploader.backends.default_storage import DefaultStorageUploadBackend

ajax_uploader = AjaxFileUploader(backend=DefaultStorageUploadBackend, UPLOAD_DIR='uploads/%Y/%m/%d')
```

or:

```
# views.py

from ajaxuploader.views import AjaxFileUploader
from ajaxuploader.backends.default_storage import DefaultStorageUploadBackend

ajax_uploader = AjaxFileUploader(backend=DefaultStorageUploadBackend, UPLOAD_DIR=lambda: something_crazy())
```

or, if more customization is needed: 

```
# views.py

from ajaxuploader.views import AjaxFileUploader
from ajaxuploader.backends.default_storage import DefaultStorageUploadBackend

class MyPathUploader(DefaultStorageUploadBackend):
    def get_upload_dir(self):
        return crazy_calculation_maybe_hash()

ajax_uploader = AjaxFileUploader(backend=MyPathUploader)
```
