### PR TITLE
ObjectId in mongo backend extra_content

### DIFF
--- a/ajaxuploader/backends/mongodb.py
+++ b/ajaxuploader/backends/mongodb.py
@@ -62,3 +62,5 @@ class MongoDBUploadBackend(AbstractUploadBackend):
 
     def upload_complete(self, request, filename, *args, **kwargs):
         self.f.close()
+        # provide a string representation of the GridFS File ObjectId
+        return {'_id': str(self.f._id)}


### PR DESCRIPTION
Added string representation of GridFS File ObjectId to the extra_content of the mongo backend.  I found that I needed this information in order to setup some other pointers to the file being stored in mongo for my application needs.
