### PR TITLE
allow date time formatting placeholders in upload dir.

### DIFF
--- a/ajaxuploader/backends/default_storage.py
+++ b/ajaxuploader/backends/default_storage.py
@@ -1,3 +1,4 @@
+import datetime
 import os
 
 from django.core.files.storage import default_storage
@@ -17,7 +18,7 @@ class DefaultStorageUploadBackend(AbstractUploadBackend):
     def _get_upload_dir(self):
         if callable(self.UPLOAD_DIR):
             return self.UPLOAD_DIR()
-        return self.UPLOAD_DIR
+        return datetime.datetime.now().strftime(self.UPLOAD_DIR)
 
     def setup(self, filename, *args, **kwargs):
         # join UPLOAD_DIR with filename.


### PR DESCRIPTION
this allows passing placeholders for datetime formatting, similarly to how Django's `FileField.upload_to` works (https://docs.djangoproject.com/en/1.6/ref/models/fields/#filefield)
