### PR TITLE
Fix upload path issue with easy thumbnails backend and corresponding documentation update

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,6 +384,17 @@ Context returned:
 
 * `path`: The full media path to the uploaded file.
 
+Example Usage:
+
+```python
+
+#views.py
+from ajaxuploader.views import AjaxFileUploader
+from ajaxuploader.backends.easythumbnails import EasyThumbnailUploadBackend
+
+import_uploader = AjaxFileUploader(UPLOAD_DIR='my_upload', backend=EasyThumbnailUploadBackend, DIMENSIONS=(250, 250)) 
+```
+
 
 Backend Usage
 ------------------------

--- a/ajaxuploader/backends/easythumbnails.py
+++ b/ajaxuploader/backends/easythumbnails.py
@@ -7,7 +7,7 @@ from ajaxuploader.backends.local import LocalUploadBackend
 
 
 class EasyThumbnailUploadBackend(LocalUploadBackend):
-    DIMENSIONS = (100, 000)
+    DIMENSIONS = (100, 100)
     CROP = True
     KEEP_ORIGINAL = False
 
@@ -19,4 +19,4 @@ class EasyThumbnailUploadBackend(LocalUploadBackend):
         if not self.KEEP_ORIGINAL:
             os.unlink(self._path)
 
-        return {"path": settings.MEDIA_URL + os.path.split(thumb.path)[1]}
+        return {"path": settings.MEDIA_URL + self.UPLOAD_DIR + '/' + os.path.split(thumb.path)[1]}


### PR DESCRIPTION
Thanks for the previous update to fix the easy thumbnail backend issues.  After testing, I found that the returned path omits (depending on what you provide) the parameter provided to 'UPLOAD_DIR' or the default upload path which is 'uploads.'

This proposed commit fixes both these issues by returning the correct path.  I've also updated the docs with a usage example for the easy thumbnails backend.
