### PR TITLE
Improve Django 1.9 support when using fine-uploader

### DIFF
--- a/ajaxuploader/views/base.py
+++ b/ajaxuploader/views/base.py
@@ -32,6 +32,8 @@ class AjaxFileUploader(object):
                 try:
                     if 'qqfile' in request.GET:
                         filename = request.GET['qqfile']
+                    elif 'qqfilename' in request.POST:
+                        filename = request.POST['qqfilename']
                     else:
                         filename = request.REQUEST['qqfilename']
                 except KeyError:


### PR DESCRIPTION
In Django 1.9 the WSGIRequest.REQUEST property is removed (https://docs.djangoproject.com/en/1.9/releases/1.9/#features-removed-in-1-9).

This means that by default uploads will fail when using fine-uploader via django-ajax-uploader. I addressed this by adding a simple if statement to try POST before REQUEST.

Tested on Django 1.9.7.

(Thanks for this great project -- I searched for ages for something nice.)
